### PR TITLE
CLI-91 Limit conncurrecy of data imports

### DIFF
--- a/test/scheduler/services/ImportDataServiceSpec.scala
+++ b/test/scheduler/services/ImportDataServiceSpec.scala
@@ -34,129 +34,169 @@ import models.TransportModeList
 import models.UnDangerousGoodsCodeList
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
-import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.when
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import play.api.test.Helpers.running
 import scheduler.connector.ErrorResponse.UnexpectedResponseStatus
 import scheduler.connector.TransitReferenceDataConnector
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import base.SpecBaseWithAppPerSuite
 
-class ImportDataServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with ScalaFutures with BeforeAndAfterEach {
+class ImportDataServiceSpec extends SpecBaseWithAppPerSuite {
 
   private val mockDataRetrieval = mock[DataRetrieval]
   private val mockConnector     = mock[TransitReferenceDataConnector]
 
-  private val appBuilder: GuiceApplicationBuilder =
+  override def guiceApplicationBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(
         bind[DataRetrieval].toInstance(mockDataRetrieval),
         bind[TransitReferenceDataConnector].toInstance(mockConnector)
       )
 
-  override def beforeEach(): Unit = {
-    reset(mockDataRetrieval)
-    reset(mockConnector)
-    super.beforeEach()
-  }
+  override def mocks: Seq[_] = super.mocks ++ Seq(mockDataRetrieval, mockConnector)
 
   ".importReferenceData" - {
 
-    "must import all reference data" in {
+    val referenceData = Seq(Json.obj("id" -> 1))
 
-      val referenceData = Seq(Json.obj("id" -> 1))
+    "must import all reference data when there are no failures on retrieving the list or posting" in {
+
       when(mockDataRetrieval.getList(any())(any())) thenReturn Future.successful(referenceData)
       when(mockConnector.post(any(), any())) thenReturn Future.successful(Right(true))
 
-      val app = appBuilder.build()
+      val service = app.injector.instanceOf[ImportDataService]
 
-      running(app) {
+      val result = service.importReferenceData().futureValue
 
-        val service = app.injector.instanceOf[ImportDataService]
+      result mustEqual true
 
-        val result = service.importReferenceData().futureValue
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesFullList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CustomsOfficesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(DocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(PreviousDocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(KindOfPackagesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportModeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(AdditionalInformationIdCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(SpecificCircumstanceIndicatorList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(UnDangerousGoodsCodeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportChargesMethodOfPaymentList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(ControlResultList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitOutsideCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCustomsOfficeLists))(any())
+      verify(mockDataRetrieval, times(15)).getList(any())(any())
 
-        result mustEqual true
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesFullList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommunityList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CustomsOfficesList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(DocumentTypeCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(PreviousDocumentTypeCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(KindOfPackagesList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(TransportModeList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(AdditionalInformationIdCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(SpecificCircumstanceIndicatorList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(UnDangerousGoodsCodeList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(TransportChargesMethodOfPaymentList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(ControlResultList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitOutsideCommunityList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCustomsOfficeLists), eqTo(referenceData))
-        verify(mockConnector, times(15)).post(any(), any())
-      }
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesFullList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommunityList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CustomsOfficesList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(DocumentTypeCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(PreviousDocumentTypeCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(KindOfPackagesList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(TransportModeList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(AdditionalInformationIdCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(SpecificCircumstanceIndicatorList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(UnDangerousGoodsCodeList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(TransportChargesMethodOfPaymentList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(ControlResultList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitOutsideCommunityList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCustomsOfficeLists), eqTo(referenceData))
+      verify(mockConnector, times(15)).post(any(), any())
+
     }
 
     "must try to import all lists, even if retrieving data for some lists fails" in {
 
-      when(mockDataRetrieval.getList(any())(any())) thenReturn Future.failed(new Exception("foo"))
+      when(mockDataRetrieval.getList(any())(any())).thenReturn(
+        Future.successful(referenceData),
+        Future.failed(new Exception("foo")),
+        Future.successful(referenceData),
+        Future.failed(new Exception("foo"))
+      )
 
-      val app = appBuilder.build()
+      val service = app.injector.instanceOf[ImportDataService]
 
-      running(app) {
+      val result = service.importReferenceData().futureValue
 
-        val service = app.injector.instanceOf[ImportDataService]
+      result mustEqual false
 
-        val result = service.importReferenceData().futureValue
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesFullList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CustomsOfficesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(DocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(PreviousDocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(KindOfPackagesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportModeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(AdditionalInformationIdCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(SpecificCircumstanceIndicatorList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(UnDangerousGoodsCodeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportChargesMethodOfPaymentList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(ControlResultList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitOutsideCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCustomsOfficeLists))(any())
+      verify(mockDataRetrieval, times(15)).getList(any())(any())
 
-        result mustEqual false
-        verify(mockDataRetrieval, times(15)).getList(any())(any())
-        verify(mockConnector, times(0)).post(any(), any())
-      }
+      verify(mockConnector, times(2)).post(any(), any())
     }
 
     "must try to import all lists, even if posting some data to transit-reference-data fails" in {
 
       val referenceData = Seq(Json.obj("id" -> 1))
-      when(mockDataRetrieval.getList(any())(any())) thenReturn Future.successful(referenceData)
-      when(mockConnector.post(any(), any())) thenReturn Future.successful(Left(UnexpectedResponseStatus(500, "foo")))
+      when(mockDataRetrieval.getList(any())(any())).thenReturn(Future.successful(referenceData))
+      when(mockConnector.post(any(), any())).thenReturn(
+        Future.successful(Left(UnexpectedResponseStatus(500, "foo"))),
+        Future.successful(Right(true)),
+        Future.successful(Left(UnexpectedResponseStatus(500, "foo")))
+      )
 
-      val app = appBuilder.build()
+      val service = app.injector.instanceOf[ImportDataService]
 
-      running(app) {
+      val result = service.importReferenceData().futureValue
 
-        val service = app.injector.instanceOf[ImportDataService]
+      result mustEqual false
 
-        val result = service.importReferenceData().futureValue
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesFullList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CustomsOfficesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(DocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(PreviousDocumentTypeCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(KindOfPackagesList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportModeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(AdditionalInformationIdCommonList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(SpecificCircumstanceIndicatorList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(UnDangerousGoodsCodeList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(TransportChargesMethodOfPaymentList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(ControlResultList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCommonTransitOutsideCommunityList))(any())
+      verify(mockDataRetrieval, times(1)).getList(eqTo(CountryCodesCustomsOfficeLists))(any())
+      verify(mockDataRetrieval, times(15)).getList(any())(any())
 
-        result mustEqual false
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesFullList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommunityList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CustomsOfficesList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(DocumentTypeCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(PreviousDocumentTypeCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(KindOfPackagesList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(TransportModeList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(AdditionalInformationIdCommonList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(SpecificCircumstanceIndicatorList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(UnDangerousGoodsCodeList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(TransportChargesMethodOfPaymentList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(ControlResultList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitOutsideCommunityList), eqTo(referenceData))
-        verify(mockConnector, times(1)).post(eqTo(CountryCodesCustomsOfficeLists), eqTo(referenceData))
-        verify(mockConnector, times(15)).post(any(), any())
-      }
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesFullList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommunityList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CustomsOfficesList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(DocumentTypeCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(PreviousDocumentTypeCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(KindOfPackagesList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(TransportModeList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(AdditionalInformationIdCommonList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(SpecificCircumstanceIndicatorList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(UnDangerousGoodsCodeList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(TransportChargesMethodOfPaymentList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(ControlResultList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCommonTransitOutsideCommunityList), eqTo(referenceData))
+      verify(mockConnector, times(1)).post(eqTo(CountryCodesCustomsOfficeLists), eqTo(referenceData))
+      verify(mockConnector, times(15)).post(any(), any())
+
     }
 
   }


### PR DESCRIPTION
Limit concurrency of data imports to max of 5 at a time. This also changes the order so that customs reference data only occurs with no other current data imports.